### PR TITLE
fix（ゲスト対応）: ミドルウェア適応変更、ゲストボタン、ゲスト対応画面

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -62,5 +62,5 @@ export async function middleware(req: NextRequest) {
 
 /* --- ⑤ 適用パス ------------------------------------------------------------- */
 export const config = {
-  matcher: ["/(.*)"], 
+  matcher: ["/auth/:path*"], // /auth 配下のみ
 };

--- a/src/app/(pages)/profile/page.tsx
+++ b/src/app/(pages)/profile/page.tsx
@@ -1,40 +1,48 @@
-// app/profile/page.tsx
+// app/(pages)/profile/page.tsx
 import { verifyIdToken } from "@/app/actions/verify";
-import Link from "next/link";
 import { redirect } from "next/navigation";
 
 export default async function ProfilePage() {
-  // ① Server Action を直接呼び出してペイロードを取得
-  let user;
-  try {
-    user = await verifyIdToken();
-  } catch {
-    // 未ログイン・検証失敗なら / へ
-    redirect("/");
-  }
+  const user = await verifyIdToken();
 
-  // ② 取得した情報を描画 (= SSR ストリーミング)
+  // ── ログイン必須にしたい場合はここで弾く ──
+  // if (!user) redirect("/");   ← 今回はゲストも許すので削除
+
   return (
-    <main className="mx-auto max-w-xl px-4 py-10">
-      <h1 className="mb-6 text-2xl font-bold">プロフィール</h1>
+    <main className="mx-auto max-w-xl px-4 py-10 space-y-8">
+      <h1 className="text-2xl font-bold">プロフィール</h1>
 
-      <section className="space-y-2 text-lg">
-        <p><strong>ユーザー ID (sub):</strong> {user.sub}</p>
-        <p><strong>メール:</strong> {user.email}</p>
-        {user.name && <p><strong>表示名:</strong> {user.name}</p>}
-        <p className="text-sm text-gray-500">
-          トークン有効期限 (exp): {new Date(user.exp * 1000).toLocaleString()}
-        </p>
-      </section>
+      {user ? (
+        /* 認証ユーザー用ビュー */
+        <section className="space-y-2 text-lg">
+          <p><strong>ユーザー ID (sub):</strong> {user.sub}</p>
+          <p><strong>メール:</strong> {user.email}</p>
+          {user.name && <p><strong>表示名:</strong> {user.name}</p>}
+          <p className="text-sm text-gray-500">
+            トークン有効期限: {new Date(user.exp * 1000).toLocaleString()}
+          </p>
+        </section>
+      ) : (
+        /* ★ ゲスト用ビュー */
+        <section className="space-y-4 text-center">
+          <p className="text-lg">あなたは <strong>ゲスト</strong> としてプレイ中です。</p>
+          <p className="text-sm text-gray-500">
+            ログインすると戦績の保存やパスキー登録ができます。
+          </p>
+        </section>
+      )}
 
-      <section className="mt-8">
-        <a
-          href="/auth/passkey/add"
-          className="inline-block rounded bg-blue-600 px-4 py-2 text-white"
-        >
-          パスキーを追加
-        </a>
-      </section>
+      {/* 認証ユーザーのみ表示したいボタンはガード */}
+      {user && (
+        <section>
+          <a
+            href="/auth/passkey/add"
+            className="inline-block rounded bg-blue-600 px-4 py-2 text-white"
+          >
+            パスキーを追加
+          </a>
+        </section>
+      )}
     </main>
   );
 }

--- a/src/app/actions/verify.ts
+++ b/src/app/actions/verify.ts
@@ -1,40 +1,33 @@
+// app/actions/verify.ts
 "use server";
 
 import { cookies } from "next/headers";
 import { CognitoJwtVerifier } from "aws-jwt-verify";
 
-// ① Verifier をシングルトンで作成
 const verifier = CognitoJwtVerifier.create({
   userPoolId: process.env.NEXT_PUBLIC_COG_POOL_ID!,
   clientId:   process.env.NEXT_PUBLIC_COG_CLIENT_ID!,
   tokenUse: "id",
 });
 
-/**
- * フォーム submit で呼ばれる Server Action
- * - id_token Cookie を取得
- * - 署名・iss・aud・exp を検証
- */
 export async function verifyIdToken(): Promise<{
   sub: string;
   email: string;
   name: string;
   exp: number;
-}> {
+} | null> {
   const token = (await cookies()).get("id_token")?.value;
+  if (!token) return null;          // ★ ゲストは null を返す
 
-  if (!token) {
-    throw new Error("id_token が存在しません。");
+  try {
+    const p = await verifier.verify(token);
+    return {
+      sub:   p.sub as string,
+      email: p.email as string,
+      name:  p.name as string,
+      exp:   p.exp as number,
+    };
+  } catch {
+    return null; // 検証エラーもゲスト扱い
   }
-
-  // ② 署名検証（失敗すると例外）
-  const payload = await verifier.verify(token);
-
-  // 検証後のペイロードを戻り値として返す（ページ側で利用可能）
-  return {
-    sub:          payload.sub as string,
-    email:        payload.email as string,
-    name:         payload.name as string,
-    exp:          payload.exp as number,
-  };
 }

--- a/src/app/components/GuestButton.tsx
+++ b/src/app/components/GuestButton.tsx
@@ -1,0 +1,16 @@
+// app/components/GuestButton.tsx
+"use client";
+
+import Link from "next/link";
+
+export default function GuestButton() {
+  return (
+    <Link
+      href="/profile"      // サーバーリダイレクト用ルート
+      prefetch={false}         // 外部遷移と同様にプリフェッチさせない
+      className="inline-block rounded border px-4 py-2"
+    >
+      ゲストとして入る
+    </Link>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,11 @@
 import LoginButton from "@/app/components/LoginButton";
+import GuestButton from "@/app/components/GuestButton";
 
 export default function Home() {
   return (
     <main className="flex min-h-screen items-center justify-center">
         <LoginButton />
+        <GuestButton />
     </main>
   );
 }


### PR DESCRIPTION
# 概要
<!-- なぜこの変更を行ったのかもあるとgood -->
ゲストアカウントでのゲーム参加を許すための認証を再構築した。

# 詳細
<!-- 箇条書きで -->
- ミドルウェアのマッチャーを変更して、authフォルダのみにした
- ゲストボタンを最初のページ入れる
- ゲストの場合のプロフィール画面を実装

# テスト・動作確認の方法

* ENVファイルを用意した上で、（シークレットウィンドウで）ゲストユーザーでのログインをしたら特に変なことにリダイレクトされることなくうまく画面が表示されるはず。

## スクリーンショット
<!-- 必要に応じて -->

# その他
