### PR TITLE
fix:クイズ画面からリザルト画面へ自動遷移

### DIFF
--- a/src/app/(pages)/quizScreen/page.tsx
+++ b/src/app/(pages)/quizScreen/page.tsx
@@ -7,6 +7,8 @@ import { Progress } from "@/components/ui/progress";
 import { Button } from "@/components/ui/button";
 import { Alert, AlertTitle } from "@/components/ui/alert";
 import { PushButton } from "@/app/(pages)/Home/components/PushButton";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
 
 // --- Type Definitions ---
 interface Participant {
@@ -70,6 +72,7 @@ const QuizScreenPage = () => {
   const [userAnswer, setUserAnswer] = useState("");
   const [choices, setChoices] = useState<string[]>([]);
 
+  const router = useRouter();
   const currentQuestion = quizQuestions[currentQuestionIndex];
   const thisPlayer = playerScores[0];
 
@@ -139,7 +142,11 @@ const QuizScreenPage = () => {
       const timer = setTimeout(handleNextQuestion, 2000);
       return () => clearTimeout(timer);
     }
-  }, [gamePhase, handleRetry, handleNextQuestion]);
+    if (gamePhase === "finished") {
+        const timer = setTimeout(() => router.push('/resultScreen'), 2000);
+        return () => clearTimeout(timer);
+    }
+  }, [gamePhase, handleRetry, handleNextQuestion, router]);
 
   const handleStartAnswering = () => {
     setIsTimerActive(false);
@@ -236,7 +243,7 @@ const QuizScreenPage = () => {
                                 <AlertTitle className="font-bold">
                                     {gamePhase === "correct" && "正解 (Correct)!"}
                                     {gamePhase === "incorrect" && "不正解 (Incorrect)!"}
-                                    {gamePhase === "finished" && "Quiz Complete!"}
+                                    {gamePhase === "finished" && <Link href="/resultScreen">Quiz Complete!</Link>}
                                 </AlertTitle>
                             </Alert>
                         )}


### PR DESCRIPTION
# 概要
<!-- なぜこの変更を行ったのかもあるとgood -->

# 詳細
<!-- 箇条書きで -->
- 例：/home/で部屋作成のapiを叩いてリクエスト送信

# テスト・動作確認の方法

* [ ] 例：...にアクセスして...を押して...のようになるか確認

## スクリーンショット
<!-- 必要に応じて -->

# その他
